### PR TITLE
feat: add project documentation

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -8,6 +8,9 @@ import { pageview } from './lib/gtag'
 function Nav() {
   const { theme, setTheme } = useTheme()
   const location = useLocation()
+  const docsActive = ['/docs', '/downmark', '/pdf'].some(
+    (path) => location.pathname === path || location.pathname.startsWith(`${path}/`),
+  )
 
   const toggleTheme = useCallback(() => {
     setTheme(theme === 'light' ? 'dark' : 'light')
@@ -29,6 +32,9 @@ function Nav() {
             className={`nav-link hidden sm:block ${location.pathname === '/' ? 'active' : ''}`}
           >
             Home
+          </Link>
+          <Link to='/docs' className={`nav-link ${docsActive ? 'active' : ''}`}>
+            Docs
           </Link>
           <Link
             to='/blog'

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -8,7 +8,7 @@ import { pageview } from './lib/gtag'
 function Nav() {
   const { theme, setTheme } = useTheme()
   const location = useLocation()
-  const docsActive = ['/docs', '/downmark', '/pdf'].some(
+  const docsActive = ['/docs', '/downmark', '/pdf', '/openapi-go-naming'].some(
     (path) => location.pathname === path || location.pathname.startsWith(`${path}/`),
   )
 

--- a/app/components/docs/DocsPage.tsx
+++ b/app/components/docs/DocsPage.tsx
@@ -21,6 +21,11 @@ interface DocsPageProps {
 const projects = [
   { to: '/downmark', name: 'downmark', summary: 'Documents to Markdown' },
   { to: '/pdf', name: 'pdf', summary: 'PDF text extraction' },
+  {
+    to: '/openapi-go-naming',
+    name: 'openapi-go-naming',
+    summary: 'OpenAPI names for Go',
+  },
 ]
 
 function usePageMetadata(name: string, description: string) {

--- a/app/components/docs/DocsPage.tsx
+++ b/app/components/docs/DocsPage.tsx
@@ -1,0 +1,324 @@
+import { type ReactNode, useEffect, useState } from 'react'
+import { FaGithub } from 'react-icons/fa6'
+import { HiCheck, HiClipboardDocument, HiOutlineBookOpen } from 'react-icons/hi2'
+import { Link, useLocation } from 'react-router'
+
+export interface DocsSectionLink {
+  id: string
+  label: string
+}
+
+interface DocsPageProps {
+  children: ReactNode
+  description: string
+  githubUrl: string
+  highlights: string[]
+  name: string
+  pkgGoDevUrl: string
+  sections: DocsSectionLink[]
+}
+
+const projects = [
+  { to: '/downmark', name: 'downmark', summary: 'Documents to Markdown' },
+  { to: '/pdf', name: 'pdf', summary: 'PDF text extraction' },
+]
+
+function usePageMetadata(name: string, description: string) {
+  useEffect(() => {
+    document.title = `${name} documentation | giraffesyo.io`
+
+    let meta = document.querySelector<HTMLMetaElement>('meta[name="description"]')
+    const created = !meta
+    const previous = meta?.content
+    if (!meta) {
+      meta = document.createElement('meta')
+      meta.name = 'description'
+      document.head.appendChild(meta)
+    }
+    meta.content = description
+
+    return () => {
+      if (created) {
+        meta?.remove()
+      } else if (meta && previous !== undefined) {
+        meta.content = previous
+      }
+    }
+  }, [description, name])
+}
+
+export default function DocsPage({
+  children,
+  description,
+  githubUrl,
+  highlights,
+  name,
+  pkgGoDevUrl,
+  sections,
+}: DocsPageProps) {
+  const location = useLocation()
+  const [activeSection, setActiveSection] = useState(sections[0]?.id ?? '')
+  usePageMetadata(name, description)
+
+  useEffect(() => {
+    const updateActiveSection = () => {
+      const headerOffset = 140
+      let current = sections[0]?.id ?? ''
+
+      for (const section of sections) {
+        const element = document.getElementById(section.id)
+        if (!element || element.getBoundingClientRect().top > headerOffset) break
+        current = section.id
+      }
+
+      const atPageBottom = window.innerHeight + window.scrollY >= document.body.scrollHeight - 2
+      if (atPageBottom && sections.length > 0) {
+        current = sections[sections.length - 1].id
+      }
+
+      setActiveSection(current)
+    }
+
+    updateActiveSection()
+    window.addEventListener('scroll', updateActiveSection, { passive: true })
+    window.addEventListener('resize', updateActiveSection)
+
+    return () => {
+      window.removeEventListener('scroll', updateActiveSection)
+      window.removeEventListener('resize', updateActiveSection)
+    }
+  }, [sections])
+
+  return (
+    <div className='px-6 py-16 sm:py-20'>
+      <div className='max-w-6xl mx-auto'>
+        <header className='pb-12 border-b border-stone-200 dark:border-zinc-800'>
+          <div className='flex items-center gap-2 font-mono text-xs text-stone-400 dark:text-zinc-500 mb-6'>
+            <Link to='/docs' className='hover:text-accent transition-colors'>
+              docs
+            </Link>
+            <span>/</span>
+            <span className='text-accent'>{name}</span>
+          </div>
+
+          <div className='flex flex-col lg:flex-row lg:items-end lg:justify-between gap-8'>
+            <div className='max-w-3xl'>
+              <h1 className='font-display text-4xl sm:text-6xl font-bold tracking-tight text-stone-900 dark:text-zinc-50'>
+                {name}
+              </h1>
+              <p className='mt-5 text-lg sm:text-xl leading-relaxed text-stone-500 dark:text-zinc-400'>
+                {description}
+              </p>
+              <div className='flex flex-wrap gap-2 mt-6'>
+                {highlights.map((highlight) => (
+                  <span
+                    key={highlight}
+                    className='px-3 py-1 rounded-full font-mono text-xs border border-stone-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/60 text-stone-500 dark:text-zinc-400'
+                  >
+                    {highlight}
+                  </span>
+                ))}
+              </div>
+            </div>
+
+            <div className='flex flex-wrap gap-3 shrink-0'>
+              <a
+                href={githubUrl}
+                target='_blank'
+                rel='noopener noreferrer'
+                className='btn-secondary'
+              >
+                <FaGithub className='w-4 h-4' />
+                GitHub
+              </a>
+              <a
+                href={pkgGoDevUrl}
+                target='_blank'
+                rel='noopener noreferrer'
+                className='btn-primary'
+              >
+                <HiOutlineBookOpen className='w-4 h-4' />
+                Go reference
+              </a>
+            </div>
+          </div>
+        </header>
+
+        <nav className='lg:hidden flex gap-2 py-6 overflow-x-auto' aria-label='Documentation'>
+          {projects.map((project) => (
+            <Link
+              key={project.to}
+              to={project.to}
+              className={`shrink-0 px-4 py-2 rounded-lg border font-mono text-sm transition-colors ${
+                location.pathname === project.to
+                  ? 'border-accent bg-accent-muted text-accent'
+                  : 'border-stone-200 dark:border-zinc-800 text-stone-500 dark:text-zinc-400'
+              }`}
+            >
+              {project.name}
+            </Link>
+          ))}
+        </nav>
+
+        <div className='grid lg:grid-cols-[220px_minmax(0,1fr)] gap-12 lg:gap-16 pt-10'>
+          <aside className='hidden lg:block'>
+            <div className='sticky top-24 space-y-8'>
+              <nav aria-label='Documentation projects'>
+                <p className='font-mono text-xs tracking-widest uppercase text-stone-400 dark:text-zinc-600 mb-3'>
+                  Projects
+                </p>
+                <div className='space-y-1'>
+                  {projects.map((project) => {
+                    const active = location.pathname === project.to
+                    return (
+                      <Link
+                        key={project.to}
+                        to={project.to}
+                        className={`block rounded-lg px-3 py-2.5 transition-colors ${
+                          active
+                            ? 'bg-accent-muted text-accent'
+                            : 'text-stone-500 dark:text-zinc-400 hover:bg-stone-100 dark:hover:bg-zinc-900'
+                        }`}
+                      >
+                        <span className='block font-mono text-sm'>{project.name}</span>
+                        <span className='block text-xs mt-0.5 opacity-70'>{project.summary}</span>
+                      </Link>
+                    )
+                  })}
+                </div>
+              </nav>
+
+              <nav aria-label='On this page'>
+                <p className='font-mono text-xs tracking-widest uppercase text-stone-400 dark:text-zinc-600 mb-3'>
+                  On this page
+                </p>
+                <div className='border-l border-stone-200 dark:border-zinc-800 space-y-1'>
+                  {sections.map((section) => (
+                    <a
+                      key={section.id}
+                      href={`#${section.id}`}
+                      aria-current={activeSection === section.id ? 'location' : undefined}
+                      onClick={() => setActiveSection(section.id)}
+                      className={`block -ml-px pl-4 py-1.5 border-l text-sm transition-colors ${
+                        activeSection === section.id
+                          ? 'border-accent text-accent font-medium'
+                          : 'border-transparent text-stone-500 dark:text-zinc-500 hover:border-accent hover:text-accent'
+                      }`}
+                    >
+                      {section.label}
+                    </a>
+                  ))}
+                </div>
+              </nav>
+            </div>
+          </aside>
+
+          <main className='min-w-0 max-w-3xl'>{children}</main>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface DocSectionProps {
+  children: ReactNode
+  id: string
+  title: string
+}
+
+export function DocSection({ children, id, title }: DocSectionProps) {
+  return (
+    <section id={id} className='scroll-mt-28 mb-16'>
+      <h2 className='font-display text-2xl sm:text-3xl font-semibold text-stone-900 dark:text-zinc-50 mb-5'>
+        {title}
+      </h2>
+      <div className='docs-content'>{children}</div>
+    </section>
+  )
+}
+
+export function DocSubsection({ children, title }: { children: ReactNode; title: string }) {
+  return (
+    <section className='mt-10'>
+      <h3 className='font-display text-xl font-semibold text-stone-900 dark:text-zinc-100 mb-3'>
+        {title}
+      </h3>
+      {children}
+    </section>
+  )
+}
+
+export function CodeBlock({ children, label }: { children: string; label?: string }) {
+  const [copied, setCopied] = useState(false)
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(children)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1600)
+    } catch {
+      setCopied(false)
+    }
+  }
+
+  return (
+    <div className='relative my-6 group'>
+      {label && (
+        <div className='remark-code-title flex items-center justify-between'>
+          <span>{label}</span>
+        </div>
+      )}
+      <pre className={label ? 'mt-0 rounded-t-none pr-14' : 'pr-14'}>
+        <code>{children}</code>
+      </pre>
+      <button
+        type='button'
+        onClick={copy}
+        className={`absolute right-3 ${label ? 'top-10' : 'top-3'} p-2 rounded-md border border-stone-200 dark:border-zinc-700 bg-white/90 dark:bg-zinc-800/90 text-stone-400 dark:text-zinc-400 hover:text-accent hover:border-accent transition-colors`}
+        aria-label='Copy code'
+      >
+        {copied ? (
+          <HiCheck className='w-4 h-4 text-green-500' />
+        ) : (
+          <HiClipboardDocument className='w-4 h-4' />
+        )}
+      </button>
+    </div>
+  )
+}
+
+export function Callout({ children, title }: { children: ReactNode; title?: string }) {
+  return (
+    <aside className='my-6 rounded-xl border border-accent/20 bg-accent-muted px-5 py-4 text-stone-600 dark:text-zinc-300'>
+      {title && <p className='font-mono text-sm font-medium text-accent mb-1'>{title}</p>}
+      <div className='text-sm leading-relaxed'>{children}</div>
+    </aside>
+  )
+}
+
+export function DocsTable({ children, headers }: { children: ReactNode; headers: string[] }) {
+  return (
+    <div className='overflow-x-auto my-6 rounded-xl border border-stone-200 dark:border-zinc-800'>
+      <table className='w-full text-left text-sm'>
+        <thead className='bg-stone-100/80 dark:bg-zinc-900 text-stone-700 dark:text-zinc-300'>
+          <tr>
+            {headers.map((header) => (
+              <th key={header} className='px-4 py-3 font-mono text-xs font-medium'>
+                {header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className='divide-y divide-stone-200 dark:divide-zinc-800'>{children}</tbody>
+      </table>
+    </div>
+  )
+}
+
+export function TableCell({ children, code = false }: { children: ReactNode; code?: boolean }) {
+  return (
+    <td className='px-4 py-3 align-top text-stone-600 dark:text-zinc-400 leading-relaxed'>
+      {code ? <code>{children}</code> : children}
+    </td>
+  )
+}

--- a/app/router.tsx
+++ b/app/router.tsx
@@ -24,6 +24,10 @@ export const router = createBrowserRouter([
         path: 'pdf',
         lazy: async () => ({ Component: (await import('./routes/PdfDocs')).default }),
       },
+      {
+        path: 'openapi-go-naming',
+        lazy: async () => ({ Component: (await import('./routes/OpenApiGoNamingDocs')).default }),
+      },
       { path: '*', Component: NotFound },
     ],
   },

--- a/app/router.tsx
+++ b/app/router.tsx
@@ -12,6 +12,18 @@ export const router = createBrowserRouter([
       { index: true, Component: Home },
       { path: 'blog', Component: BlogList },
       { path: 'blog/:slug', Component: BlogPost },
+      {
+        path: 'docs',
+        lazy: async () => ({ Component: (await import('./routes/Docs')).default }),
+      },
+      {
+        path: 'downmark',
+        lazy: async () => ({ Component: (await import('./routes/DownmarkDocs')).default }),
+      },
+      {
+        path: 'pdf',
+        lazy: async () => ({ Component: (await import('./routes/PdfDocs')).default }),
+      },
       { path: '*', Component: NotFound },
     ],
   },

--- a/app/routes/Docs.tsx
+++ b/app/routes/Docs.tsx
@@ -1,0 +1,101 @@
+import { useEffect } from 'react'
+import { FaGithub } from 'react-icons/fa6'
+import { HiArrowRight, HiCodeBracket, HiDocumentText } from 'react-icons/hi2'
+import { Link } from 'react-router'
+import FadeIn from '../components/FadeIn'
+
+const projects = [
+  {
+    name: 'downmark',
+    description:
+      'Convert PDF, Word, Excel, PowerPoint, HTML, CSV, ZIP, and plain-text documents into clean Markdown.',
+    to: '/downmark',
+    github: 'https://github.com/giraffesyo/downmark',
+    icon: HiDocumentText,
+    details: ['CLI + Go library', 'Format-selective linking', 'Pure Go'],
+  },
+  {
+    name: 'pdf',
+    description:
+      'Extract readable text and positioned glyphs from real-world PDF files with a zero-dependency Go package.',
+    to: '/pdf',
+    github: 'https://github.com/giraffesyo/pdf',
+    icon: HiCodeBracket,
+    details: ['Positioned glyphs', 'Zero dependencies', 'Hostile-file budgets'],
+  },
+]
+
+export default function Docs() {
+  useEffect(() => {
+    document.title = 'Documentation | giraffesyo.io'
+  }, [])
+
+  return (
+    <div className='px-6 py-20 sm:py-24'>
+      <div className='max-w-6xl mx-auto'>
+        <FadeIn>
+          <div className='section-label max-w-3xl'>
+            <span>Open source</span>
+          </div>
+          <h1 className='font-display text-4xl sm:text-6xl font-bold tracking-tight text-stone-900 dark:text-zinc-50 max-w-3xl'>
+            Project documentation
+          </h1>
+          <p className='mt-5 text-lg sm:text-xl leading-relaxed text-stone-500 dark:text-zinc-400 max-w-2xl'>
+            Guides and API notes for Go tools built around document conversion and extraction.
+          </p>
+        </FadeIn>
+
+        <div className='grid md:grid-cols-2 gap-6 mt-14'>
+          {projects.map((project, index) => {
+            const Icon = project.icon
+            return (
+              <FadeIn key={project.name} delay={0.1 * (index + 1)}>
+                <article className='card group relative h-full p-7 sm:p-8 flex flex-col focus-within:ring-2 focus-within:ring-accent/40'>
+                  <Link
+                    to={project.to}
+                    className='absolute inset-0 rounded-xl'
+                    aria-label={`Read the ${project.name} documentation`}
+                  />
+                  <div className='w-11 h-11 rounded-xl bg-accent-muted text-accent flex items-center justify-center mb-6'>
+                    <Icon className='w-5 h-5' />
+                  </div>
+                  <h2 className='font-display text-2xl font-semibold text-stone-900 dark:text-zinc-50'>
+                    {project.name}
+                  </h2>
+                  <p className='text-stone-500 dark:text-zinc-400 leading-relaxed mt-3'>
+                    {project.description}
+                  </p>
+                  <div className='flex flex-wrap gap-2 mt-5'>
+                    {project.details.map((detail) => (
+                      <span
+                        key={detail}
+                        className='font-mono text-xs px-2.5 py-1 rounded-full bg-stone-100 dark:bg-zinc-800 text-stone-500 dark:text-zinc-400'
+                      >
+                        {detail}
+                      </span>
+                    ))}
+                  </div>
+                  <div className='flex items-center gap-5 mt-8 pt-6 border-t border-stone-200 dark:border-zinc-800'>
+                    <span className='inline-flex items-center gap-2 text-sm font-medium text-accent group-hover:text-accent-hover transition-colors'>
+                      Read the docs
+                      <HiArrowRight className='w-4 h-4' />
+                    </span>
+                    <a
+                      href={project.github}
+                      target='_blank'
+                      rel='noopener noreferrer'
+                      className='relative z-10 inline-flex items-center gap-2 text-sm text-stone-400 dark:text-zinc-500 hover:text-stone-900 dark:hover:text-zinc-100 transition-colors'
+                    >
+                      <FaGithub className='w-4 h-4' />
+                      Source
+                    </a>
+                  </div>
+                </article>
+              </FadeIn>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/routes/Docs.tsx
+++ b/app/routes/Docs.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import { FaGithub } from 'react-icons/fa6'
-import { HiArrowRight, HiCodeBracket, HiDocumentText } from 'react-icons/hi2'
+import { HiArrowRight, HiCodeBracket, HiDocumentText, HiTag } from 'react-icons/hi2'
 import { Link } from 'react-router'
 import FadeIn from '../components/FadeIn'
 
@@ -22,6 +22,15 @@ const projects = [
     github: 'https://github.com/giraffesyo/pdf',
     icon: HiCodeBracket,
     details: ['Positioned glyphs', 'Zero dependencies', 'Hostile-file budgets'],
+  },
+  {
+    name: 'openapi-go-naming',
+    description:
+      'Convert OpenAPI identifiers into idiomatic, deterministic, and collision-safe Go names.',
+    to: '/openapi-go-naming',
+    github: 'https://github.com/giraffesyo/openapi-go-naming',
+    icon: HiTag,
+    details: ['Valid Go identifiers', 'Collision-safe', 'Zero dependencies'],
   },
 ]
 
@@ -45,7 +54,7 @@ export default function Docs() {
           </p>
         </FadeIn>
 
-        <div className='grid md:grid-cols-2 gap-6 mt-14'>
+        <div className='grid md:grid-cols-2 lg:grid-cols-3 gap-6 mt-14'>
           {projects.map((project, index) => {
             const Icon = project.icon
             return (

--- a/app/routes/DownmarkDocs.tsx
+++ b/app/routes/DownmarkDocs.tsx
@@ -1,0 +1,437 @@
+import { Link } from 'react-router'
+import DocsPage, {
+  Callout,
+  CodeBlock,
+  DocSection,
+  DocSubsection,
+  type DocsSectionLink,
+  DocsTable,
+  TableCell,
+} from '../components/docs/DocsPage'
+
+const sections: DocsSectionLink[] = [
+  { id: 'quick-start', label: 'Quick start' },
+  { id: 'formats', label: 'Supported formats' },
+  { id: 'cli', label: 'CLI reference' },
+  { id: 'library', label: 'Go library' },
+  { id: 'detection', label: 'Detection & streams' },
+  { id: 'limits', label: 'Limits & safety' },
+  { id: 'custom-converters', label: 'Custom converters' },
+  { id: 'errors', label: 'Errors' },
+  { id: 'limitations', label: 'Limitations' },
+]
+
+const formats = [
+  ['PDF', 'convert/pdf', 'Text and layout reconstruction; scanned PDFs require OCR elsewhere.'],
+  ['DOC', 'convert/doc', 'Word 97–2003 main-document text and displayed field results.'],
+  [
+    'DOCX',
+    'convert/docx',
+    'Headings, emphasis, lists, tables, links, images, and tracked changes.',
+  ],
+  ['XLSX', 'convert/xlsx', 'Every worksheet rendered as a heading and Markdown table.'],
+  [
+    'PPTX',
+    'convert/pptx',
+    'Ordered slides, tables, chart data, image alt text, and speaker notes.',
+  ],
+  ['HTML', 'convert/html', 'Sanitized DOM conversion with GitHub-flavored Markdown tables.'],
+  ['CSV', 'convert/csv', 'Charset-aware conversion with comma, semicolon, tab, and pipe sniffing.'],
+  ['ZIP', 'convert/zipfile', 'Supported members converted under per-file headings.'],
+  ['Plain text', 'core', 'Charset-detected passthrough built into the default core engine.'],
+]
+
+const cliFlags = [
+  ['-o file', 'Write Markdown to a file instead of stdout.'],
+  ['-x .ext', 'Provide an extension hint; the leading dot is optional.'],
+  ['-m type', 'Provide a MIME type hint, such as application/pdf.'],
+  ['-c charset', 'Provide an input charset hint, such as shift_jis.'],
+  ['-keep-data-uris', 'Keep full data URIs in HTML and DOCX output.'],
+  ['-version', 'Print the installed version.'],
+]
+
+export default function DownmarkDocs() {
+  return (
+    <DocsPage
+      name='downmark'
+      description='Turn documents into clean, LLM-friendly Markdown with a single Go binary or a format-selective library.'
+      githubUrl='https://github.com/giraffesyo/downmark'
+      pkgGoDevUrl='https://pkg.go.dev/github.com/giraffesyo/downmark'
+      highlights={['Pure Go', 'CLI + library', 'No external tools']}
+      sections={sections}
+    >
+      <DocSection id='quick-start' title='Quick start'>
+        <p>
+          Downmark converts common document formats without Python, cgo, or subprocesses. Install
+          the command, point it at a document, and receive normalized Markdown on stdout.
+        </p>
+
+        <CodeBlock label='Terminal'>{`go install github.com/giraffesyo/downmark/cmd/downmark@latest
+downmark report.pdf > report.md`}</CodeBlock>
+
+        <p>
+          Use <code>-o</code> when you want Downmark to create the output file itself.
+        </p>
+
+        <CodeBlock label='Terminal'>{`downmark -o slides.md slides.pptx
+cat legacy-report.doc | downmark -x doc > legacy-report.md
+curl -sS https://example.com/report | downmark -m application/pdf > report.md`}</CodeBlock>
+
+        <Callout title='No OCR'>
+          Image-only PDFs and text converted to vector outlines have no extractable text. Downmark
+          reports that condition instead of silently returning an empty document.
+        </Callout>
+      </DocSection>
+
+      <DocSection id='formats' title='Supported formats'>
+        <p>
+          The CLI includes every converter. Library consumers can import only the format packages
+          they need, keeping unused conversion stacks out of the final binary.
+        </p>
+
+        <DocsTable headers={['Format', 'Package', 'Output behavior']}>
+          {formats.map(([format, pkg, behavior]) => (
+            <tr key={format}>
+              <TableCell>{format}</TableCell>
+              <TableCell code>{pkg}</TableCell>
+              <TableCell>{behavior}</TableCell>
+            </tr>
+          ))}
+        </DocsTable>
+
+        <p>
+          PDF extraction is powered by the standalone{' '}
+          <Link to='/pdf'>github.com/giraffesyo/pdf</Link> package, which is also available directly
+          when you need positioned glyphs or plain text without Markdown conversion.
+        </p>
+      </DocSection>
+
+      <DocSection id='cli' title='CLI reference'>
+        <CodeBlock>{`usage: downmark [flags] [file]
+
+Reads file, or stdin if omitted or "-", and writes Markdown to stdout.`}</CodeBlock>
+
+        <DocsTable headers={['Flag', 'Purpose']}>
+          {cliFlags.map(([flag, purpose]) => (
+            <tr key={flag}>
+              <TableCell code>{flag}</TableCell>
+              <TableCell>{purpose}</TableCell>
+            </tr>
+          ))}
+        </DocsTable>
+
+        <DocSubsection title='Exit codes'>
+          <DocsTable headers={['Code', 'Meaning']}>
+            <tr>
+              <TableCell code>0</TableCell>
+              <TableCell>Conversion completed successfully.</TableCell>
+            </tr>
+            <tr>
+              <TableCell code>1</TableCell>
+              <TableCell>Conversion or output writing failed.</TableCell>
+            </tr>
+            <tr>
+              <TableCell code>2</TableCell>
+              <TableCell>Arguments were invalid or the input file could not be opened.</TableCell>
+            </tr>
+          </DocsTable>
+        </DocSubsection>
+      </DocSection>
+
+      <DocSection id='library' title='Go library'>
+        <DocSubsection title='All formats'>
+          <p>
+            The <code>all</code> package matches the CLI: it wires every converter into one engine
+            and exposes convenience functions backed by a shared default engine.
+          </p>
+
+          <CodeBlock label='main.go'>{`package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+
+    "github.com/giraffesyo/downmark/all"
+)
+
+func main() {
+    result, err := all.ConvertFile(context.Background(), "report.docx")
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Print(result.Markdown)
+}`}</CodeBlock>
+
+          <p>
+            Create an explicit all-format engine when you need options or want to reuse the engine
+            with your own registrations.
+          </p>
+
+          <CodeBlock>{`engine := all.New(all.Options{
+    KeepDataURIs: true,
+})
+
+result, err := engine.ConvertFile(ctx, "report.docx")`}</CodeBlock>
+        </DocSubsection>
+
+        <DocSubsection title='Select only the formats you use'>
+          <p>
+            The core package includes detection, the converter registry, and plain-text passthrough.
+            Registering individual format packages means the Go linker never pulls in the others.
+          </p>
+
+          <CodeBlock label='main.go'>{`package main
+
+import (
+    "context"
+
+    "github.com/giraffesyo/downmark"
+    "github.com/giraffesyo/downmark/convert/docx"
+    "github.com/giraffesyo/downmark/convert/pdf"
+)
+
+func convert(ctx context.Context, path string) (string, error) {
+    engine := downmark.New()
+    pdf.Register(engine)
+    docx.Register(engine, docx.Options{})
+
+    result, err := engine.ConvertFile(ctx, path)
+    if err != nil {
+        return "", err
+    }
+    return result.Markdown, nil
+}`}</CodeBlock>
+
+          <p>
+            Use <code>downmark.WithoutBuiltins()</code> when you also want to remove the core
+            plain-text fallback and start with an empty registry.
+          </p>
+        </DocSubsection>
+
+        <DocSubsection title='Results'>
+          <p>
+            Successful conversions return a <code>*downmark.Result</code>. <code>Markdown</code>{' '}
+            contains normalized output; <code>Title</code> contains a document title when the source
+            format provides one.
+          </p>
+
+          <CodeBlock>{`type Result struct {
+    Markdown string
+    Title    string
+}`}</CodeBlock>
+        </DocSubsection>
+      </DocSection>
+
+      <DocSection id='detection' title='Detection and streams'>
+        <p>
+          <code>Engine.Convert</code> accepts any <code>io.Reader</code>. Provide whatever hints are
+          trustworthy; Downmark combines them with content sniffing and tries the most specific
+          matching converters first.
+        </p>
+
+        <CodeBlock>{`result, err := engine.Convert(ctx, response.Body, downmark.StreamInfo{
+    MIMEType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    Filename: "report.docx",
+    URL:      "https://example.com/report.docx",
+})`}</CodeBlock>
+
+        <DocsTable headers={['StreamInfo field', 'Meaning']}>
+          <tr>
+            <TableCell code>MIMEType</TableCell>
+            <TableCell>Media type without parameters, such as application/pdf.</TableCell>
+          </tr>
+          <tr>
+            <TableCell code>Extension</TableCell>
+            <TableCell>Lowercase extension with a leading dot, such as .docx.</TableCell>
+          </tr>
+          <tr>
+            <TableCell code>Charset</TableCell>
+            <TableCell>IANA charset name, such as utf-8 or shift_jis.</TableCell>
+          </tr>
+          <tr>
+            <TableCell code>Filename</TableCell>
+            <TableCell>Base filename, when known.</TableCell>
+          </tr>
+          <tr>
+            <TableCell code>LocalPath</TableCell>
+            <TableCell>Source path for local inputs.</TableCell>
+          </tr>
+          <tr>
+            <TableCell code>URL</TableCell>
+            <TableCell>Original URL for network inputs.</TableCell>
+          </tr>
+        </DocsTable>
+
+        <Callout title='Non-seekable readers'>
+          Streams such as HTTP bodies and stdin are buffered in memory because converters may need
+          to seek and retry. Matching Office and ZIP inputs are rejected at their compressed-input
+          limit while buffering.
+        </Callout>
+
+        <DocSubsection title='Route only recognized documents'>
+          <p>
+            <code>CanConvert</code> checks whether a dedicated converter claims the hints. It does
+            not read or sniff the input and deliberately excludes the plain-text fallback.
+          </p>
+
+          <CodeBlock>{`if engine.CanConvert(downmark.StreamInfo{Filename: upload.Name}) {
+    result, err := engine.Convert(ctx, upload, downmark.StreamInfo{
+        Filename: upload.Name,
+    })
+    // ...
+}`}</CodeBlock>
+        </DocSubsection>
+      </DocSection>
+
+      <DocSection id='limits' title='Limits and safety'>
+        <p>
+          Downmark treats document input as untrusted. Archive structure, decompressed data,
+          generated output, parser work, and PDF extraction all have bounded paths.
+        </p>
+
+        <DocsTable headers={['Input', 'Built-in budgets']}>
+          <tr>
+            <TableCell>DOCX / XLSX / PPTX</TableCell>
+            <TableCell>
+              64 MiB compressed archive, 128 MiB total uncompressed, 16 MiB per part, and 1,024
+              entries.
+            </TableCell>
+          </tr>
+          <tr>
+            <TableCell>ZIP</TableCell>
+            <TableCell>
+              64 MiB archive, 128 MiB total member data, 10 MiB per member, 64 converted members,
+              1,024 scanned entries, and 32 MiB output.
+            </TableCell>
+          </tr>
+          <tr>
+            <TableCell>PDF</TableCell>
+            <TableCell>
+              Hard budgets for decoded streams, operations, glyphs, page-tree traversal, and nested
+              Form XObjects.
+            </TableCell>
+          </tr>
+        </DocsTable>
+
+        <DocSubsection title='Set an application output budget'>
+          <p>
+            Derive the conversion context with <code>WithResultLimit</code>. A child context can
+            tighten an existing limit but cannot loosen it.
+          </p>
+
+          <CodeBlock>{`ctx := downmark.WithResultLimit(request.Context(), 4<<20) // 4 MiB
+result, err := engine.Convert(ctx, input, hints)`}</CodeBlock>
+
+          <p>
+            Converters consult the same budget while constructing large output, and the engine
+            checks it again after Markdown normalization.
+          </p>
+        </DocSubsection>
+      </DocSection>
+
+      <DocSection id='custom-converters' title='Custom converters'>
+        <p>
+          Implement <code>downmark.Converter</code> and register it at the appropriate priority.
+          <code>Accepts</code> must use only <code>StreamInfo</code>; content sniffing happens
+          before the method is called.
+        </p>
+
+        <CodeBlock label='converter.go'>{`type rstConverter struct{}
+
+func (rstConverter) Name() string { return "rst" }
+
+func (rstConverter) Accepts(info downmark.StreamInfo) bool {
+    return info.Matches(
+        []string{".rst"},
+        []string{"text/x-rst"},
+    )
+}
+
+func (rstConverter) Convert(
+    ctx context.Context,
+    input io.ReadSeeker,
+    info downmark.StreamInfo,
+) (*downmark.Result, error) {
+    // Parse input, honor ctx, and consult downmark.ResultLimit(ctx)
+    // before constructing a large result.
+    return &downmark.Result{Markdown: "# Converted\n"}, nil
+}
+
+engine.Register(rstConverter{}, downmark.PrioritySpecific)`}</CodeBlock>
+
+        <p>
+          Lower priority values run first. Use <code>PrioritySpecific</code> for a concrete format,
+          <code>PriorityArchive</code> for archive walkers, and <code>PriorityGeneric</code> for
+          catch-all formats. Within the same priority, the most recently registered converter runs
+          first, allowing application converters to shadow defaults.
+        </p>
+      </DocSection>
+
+      <DocSection id='errors' title='Errors'>
+        <p>
+          Use <code>errors.Is</code> for stable error categories and <code>errors.As</code> to
+          inspect all converter attempts.
+        </p>
+
+        <CodeBlock>{`result, err := engine.Convert(ctx, input, hints)
+if err != nil {
+    switch {
+    case errors.Is(err, downmark.ErrUnsupportedFormat):
+        // No registered converter accepted the input.
+    case errors.Is(err, downmark.ErrInputTooLarge):
+        // A converter's hard input budget was exceeded.
+    case errors.Is(err, downmark.ErrResultTooLarge):
+        // The context result limit was exceeded.
+    default:
+        var conversionErr *downmark.ConversionError
+        if errors.As(err, &conversionErr) {
+            for _, attempt := range conversionErr.Attempts {
+                log.Printf("%s: %v", attempt.Converter, attempt.Err)
+            }
+        }
+    }
+}`}</CodeBlock>
+
+        <p>
+          Context cancellation and deadline errors propagate normally. A{' '}
+          <code>ConversionError</code> means one or more converters accepted the input but every
+          attempted conversion failed.
+        </p>
+      </DocSection>
+
+      <DocSection id='limitations' title='Limitations'>
+        <ul>
+          <li>There is no OCR for scanned or outlined-text PDFs.</li>
+          <li>Complex multi-column PDF layouts may interleave.</li>
+          <li>
+            Legacy DOC conversion extracts main-document text but not formatting, tables, images,
+            headers, footnotes, comments, or text boxes.
+          </li>
+          <li>
+            DOCX headers, footers, footnotes, comments, and text boxes are skipped; equations become
+            plain text and nested tables flatten.
+          </li>
+          <li>Encrypted Office files, PDFs, and ZIP archives are not decrypted.</li>
+          <li>ZIP conversion does not recurse into nested ZIP archives.</li>
+        </ul>
+
+        <p>
+          For implementation details, golden-output fixtures, and current benchmark data, see the{' '}
+          <a
+            href='https://github.com/giraffesyo/downmark'
+            target='_blank'
+            rel='noopener noreferrer'
+          >
+            source repository
+          </a>
+          .
+        </p>
+
+        <CodeBlock label='Development'>{`go test ./...
+go test -run TestGolden -update .
+golangci-lint run ./...`}</CodeBlock>
+      </DocSection>
+    </DocsPage>
+  )
+}

--- a/app/routes/OpenApiGoNamingDocs.tsx
+++ b/app/routes/OpenApiGoNamingDocs.tsx
@@ -1,0 +1,226 @@
+import DocsPage, {
+  Callout,
+  CodeBlock,
+  DocSection,
+  DocSubsection,
+  type DocsSectionLink,
+  DocsTable,
+  TableCell,
+} from '../components/docs/DocsPage'
+
+const sections: DocsSectionLink[] = [
+  { id: 'quick-start', label: 'Quick start' },
+  { id: 'conversion', label: 'Name conversion' },
+  { id: 'initialisms', label: 'Initialisms' },
+  { id: 'collisions', label: 'Collision handling' },
+  { id: 'code-generation', label: 'Code generation' },
+  { id: 'api', label: 'API reference' },
+  { id: 'performance', label: 'Performance' },
+]
+
+const conversions = [
+  ['user_id', 'UserID', 'userID'],
+  ['HTTPServerURL', 'HTTPServerURL', 'httpServerURL'],
+  ['some.dotted-name', 'SomeDottedName', 'someDottedName'],
+  ['123-response', 'N123Response', 'n123Response'],
+  ['type', 'Type', 'type_'],
+  ['用户_id', 'X用户ID', '用户ID'],
+  ['---', 'Unknown', 'unknown'],
+]
+
+export default function OpenApiGoNamingDocs() {
+  return (
+    <DocsPage
+      name='openapi-go-naming'
+      description='Convert OpenAPI identifiers into idiomatic, deterministic, and collision-safe Go names.'
+      githubUrl='https://github.com/giraffesyo/openapi-go-naming'
+      pkgGoDevUrl='https://pkg.go.dev/github.com/giraffesyo/openapi-go-naming'
+      highlights={['Go 1.25+', 'Zero dependencies', 'Concurrency-safe']}
+      sections={sections}
+    >
+      <DocSection id='quick-start' title='Quick start'>
+        <p>
+          Add the module, import it with a short package alias, and choose an exported or unexported
+          identifier based on where the generated name will be used.
+        </p>
+
+        <CodeBlock label='Terminal'>go get github.com/giraffesyo/openapi-go-naming</CodeBlock>
+
+        <CodeBlock label='generator.go'>{`import naming "github.com/giraffesyo/openapi-go-naming"
+
+typeName := naming.Exported("user_profile")   // UserProfile
+fieldName := naming.Exported("account_id")    // AccountID
+paramName := naming.Unexported("account_id")  // accountID`}</CodeBlock>
+
+        <Callout>
+          Every result is a valid Go identifier. Exported results satisfy Go's exported-name rules,
+          while unexported results remain unexported and avoid language keywords.
+        </Callout>
+      </DocSection>
+
+      <DocSection id='conversion' title='Name conversion'>
+        <p>
+          Conversion is deterministic across separator styles and existing case conventions. The
+          tokenizer recognizes case transitions, preserves conventional Go initialisms, and treats
+          non-letter and non-digit characters as boundaries.
+        </p>
+
+        <DocsTable headers={['Input', 'Exported', 'Unexported']}>
+          {conversions.map(([input, exported, unexported]) => (
+            <tr key={input}>
+              <TableCell code>{input}</TableCell>
+              <TableCell code>{exported}</TableCell>
+              <TableCell code>{unexported}</TableCell>
+            </tr>
+          ))}
+        </DocsTable>
+
+        <DocSubsection title='Guaranteed identifiers'>
+          <ul>
+            <li>
+              Empty or separator-only input becomes <code>Unknown</code> or <code>unknown</code>.
+            </li>
+            <li>
+              Names beginning with a digit receive a stable <code>N</code> or <code>n</code> prefix.
+            </li>
+            <li>
+              Unexported Go keywords receive a trailing underscore, such as <code>type_</code>.
+            </li>
+            <li>Unicode letters and digits are retained.</li>
+            <li>
+              Exported names whose first script has no uppercase form receive an <code>X</code>
+              prefix so Go recognizes them as exported.
+            </li>
+          </ul>
+        </DocSubsection>
+      </DocSection>
+
+      <DocSection id='initialisms' title='Initialisms'>
+        <p>
+          The default converter knows conventional Go initialisms, including <code>API</code>,{' '}
+          <code>HTTP</code>, <code>ID</code>, <code>JSON</code>, <code>URL</code>, and{' '}
+          <code>UUID</code>.
+        </p>
+
+        <CodeBlock>{`naming.Exported("json_api_url")   // JSONAPIURL
+naming.Unexported("http_server") // httpServer`}</CodeBlock>
+
+        <p>
+          Add project-specific initialisms by creating an immutable converter. Matching is
+          case-insensitive, and the configured canonical spelling is uppercase.
+        </p>
+
+        <CodeBlock>{`converter := naming.NewConverter("GPU", "HPC")
+
+converter.Exported("gpu_limit")    // GPULimit
+converter.Unexported("hpc_queue")  // hpcQueue`}</CodeBlock>
+
+        <Callout title='Safe to share'>
+          A <code>Converter</code> is immutable after construction and safe for concurrent use. A
+          nil converter also falls back to the standard initialism set.
+        </Callout>
+      </DocSection>
+
+      <DocSection id='collisions' title='Collision handling'>
+        <p>
+          A <code>Scope</code> allocates unique identifiers within one generated namespace. The
+          first available name is unchanged; later collisions receive the lowest available decimal
+          suffix beginning with 2.
+        </p>
+
+        <CodeBlock>{`scope := naming.NewScope("User2", "User4")
+
+scope.Unique("User") // User
+scope.Unique("User") // User3
+scope.Unique("User") // User5`}</CodeBlock>
+
+        <DocSubsection title='Reserve names later'>
+          <CodeBlock>{`var scope naming.Scope // the zero value is ready to use
+
+scope.Reserve("Error", "Client")
+scope.Unique("Error") // Error2
+scope.Unique("Model") // Model`}</CodeBlock>
+
+          <p>
+            Reservations and allocations are exact and case-sensitive. Repeating a reservation has
+            no effect. A scope is safe for concurrent use, but it must not be copied after its first
+            operation.
+          </p>
+        </DocSubsection>
+      </DocSection>
+
+      <DocSection id='code-generation' title='Code-generation pattern'>
+        <p>
+          Convert external names first, then allocate the result in the scope that represents the Go
+          namespace you are generating. Use separate scopes for package declarations, struct fields,
+          parameters, or any other independently resolved namespace.
+        </p>
+
+        <CodeBlock>{`typeNames := naming.NewScope("Client", "Error")
+
+typeName := typeNames.Unique(naming.Exported(schemaName))
+
+fieldNames := naming.NewScope()
+for _, propertyName := range propertyNames {
+    fieldName := fieldNames.Unique(naming.Exported(propertyName))
+    emitField(fieldName)
+}`}</CodeBlock>
+
+        <Callout>
+          Conversion is intentionally stateless. Collision behavior belongs to an explicit scope,
+          which keeps generated output reproducible and makes namespace boundaries visible in the
+          generator.
+        </Callout>
+      </DocSection>
+
+      <DocSection id='api' title='API reference'>
+        <DocsTable headers={['API', 'Purpose']}>
+          <tr>
+            <TableCell code>Exported(input)</TableCell>
+            <TableCell>Convert input to an exported PascalCase Go identifier.</TableCell>
+          </tr>
+          <tr>
+            <TableCell code>Unexported(input)</TableCell>
+            <TableCell>Convert input to an unexported camelCase Go identifier.</TableCell>
+          </tr>
+          <tr>
+            <TableCell code>NewConverter(initialisms...)</TableCell>
+            <TableCell>Create an immutable converter with additional initialisms.</TableCell>
+          </tr>
+          <tr>
+            <TableCell code>NewScope(reserved...)</TableCell>
+            <TableCell>Create a collision scope with names already marked unavailable.</TableCell>
+          </tr>
+          <tr>
+            <TableCell code>Scope.Reserve(names...)</TableCell>
+            <TableCell>Mark more exact identifiers as unavailable.</TableCell>
+          </tr>
+          <tr>
+            <TableCell code>Scope.Unique(identifier)</TableCell>
+            <TableCell>
+              Return the identifier or allocate its next available numeric suffix.
+            </TableCell>
+          </tr>
+        </DocsTable>
+      </DocSection>
+
+      <DocSection id='performance' title='Performance and testing'>
+        <p>
+          Conversion uses a single-pass tokenizer and writes directly into one output buffer. Common
+          ASCII conversions allocate only the returned string. The repository includes allocation
+          assertions, concurrent scope tests, fuzz tests for identifier validity and determinism,
+          and benchmarks for both conversion directions and scope allocation.
+        </p>
+
+        <CodeBlock label='Development'>{`go test ./...
+go test -bench . -benchmem -run '^$' ./...
+go test -fuzz FuzzExported -fuzztime 10s ./...`}</CodeBlock>
+
+        <p>
+          Generated identifiers are designed for code generation, not round trips: separators,
+          original capitalization, and discarded symbols cannot be recovered from the result.
+        </p>
+      </DocSection>
+    </DocsPage>
+  )
+}

--- a/app/routes/PdfDocs.tsx
+++ b/app/routes/PdfDocs.tsx
@@ -1,0 +1,357 @@
+import { Link } from 'react-router'
+import DocsPage, {
+  Callout,
+  CodeBlock,
+  DocSection,
+  DocSubsection,
+  type DocsSectionLink,
+  DocsTable,
+  TableCell,
+} from '../components/docs/DocsPage'
+
+const sections: DocsSectionLink[] = [
+  { id: 'quick-start', label: 'Quick start' },
+  { id: 'extraction', label: 'Extracting text' },
+  { id: 'glyphs', label: 'Glyph positions' },
+  { id: 'behavior', label: 'Parser behavior' },
+  { id: 'coverage', label: 'Format coverage' },
+  { id: 'pdftest', label: 'pdftest helpers' },
+  { id: 'safety', label: 'Safety model' },
+  { id: 'limitations', label: 'Limitations' },
+]
+
+const coverage = [
+  ['Classic xref tables', 'Supported', 'Traditional PDF cross-reference layout.'],
+  ['Xref streams', 'Supported', 'PDF 1.5 compressed cross-reference data.'],
+  ['Object streams', 'Supported', 'Compressed indirect objects.'],
+  ['Hybrid references', 'Supported', 'Files combining xref tables and xref streams.'],
+  ['Form XObjects', 'Supported', 'Recursive text extraction, including Google Docs exports.'],
+  ['ToUnicode CMaps', 'Supported', 'Identity-H and other composite-font decoding.'],
+  [
+    'Standard encryption',
+    'Partial',
+    'RC4, AES-128, and AES-256 when an empty password unlocks the file.',
+  ],
+  ['Image-only pages', 'No OCR', 'Returns no glyphs because images contain no PDF text operators.'],
+]
+
+export default function PdfDocs() {
+  return (
+    <DocsPage
+      name='pdf'
+      description='Extract readable text and positioned glyphs from real-world PDF files with a hardened, zero-dependency Go package.'
+      githubUrl='https://github.com/giraffesyo/pdf'
+      pkgGoDevUrl='https://pkg.go.dev/github.com/giraffesyo/pdf'
+      highlights={['Pure Go', 'Zero dependencies', 'Positioned glyphs']}
+      sections={sections}
+    >
+      <DocSection id='quick-start' title='Quick start'>
+        <p>Add the module to your Go project, open a PDF, and pass its size to the extractor.</p>
+
+        <CodeBlock label='Terminal'>go get github.com/giraffesyo/pdf</CodeBlock>
+
+        <CodeBlock label='main.go'>{`package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+    "os"
+
+    "github.com/giraffesyo/pdf"
+)
+
+func main() {
+    file, err := os.Open("report.pdf")
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer file.Close()
+
+    info, err := file.Stat()
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    document, err := pdf.Extract(context.Background(), file, info.Size())
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Println(document.Text())
+}`}</CodeBlock>
+
+        <Callout title='Input contract'>
+          <code>Extract</code> accepts an <code>io.ReaderAt</code> and an exact byte size. Files and{' '}
+          <code>bytes.Reader</code> values satisfy the interface without copying the entire PDF into
+          another buffer.
+        </Callout>
+      </DocSection>
+
+      <DocSection id='extraction' title='Extracting text'>
+        <p>
+          Extraction returns a document containing pages, and each page contains decoded glyphs.
+          Text reconstruction is available at both document and page level.
+        </p>
+
+        <CodeBlock>{`document, err := pdf.Extract(ctx, readerAt, size)
+if err != nil {
+    return err
+}
+
+wholeDocument := document.Text()
+firstPage := document.Pages[0].Text()`}</CodeBlock>
+
+        <DocsTable headers={['API', 'Behavior']}>
+          <tr>
+            <TableCell code>pdf.Extract</TableCell>
+            <TableCell>
+              Parses the file and returns positioned glyphs for every discovered page.
+            </TableCell>
+          </tr>
+          <tr>
+            <TableCell code>Document.Text</TableCell>
+            <TableCell>
+              Reconstructs all non-empty pages as plain text, separated by one blank line.
+            </TableCell>
+          </tr>
+          <tr>
+            <TableCell code>Page.Text</TableCell>
+            <TableCell>
+              Clusters glyphs by baseline, sorts each line by horizontal position, and recovers word
+              spaces from glyph gaps and font metrics.
+            </TableCell>
+          </tr>
+        </DocsTable>
+
+        <DocSubsection title='Extract from memory'>
+          <CodeBlock>{`data, err := os.ReadFile("report.pdf")
+if err != nil {
+    return err
+}
+
+reader := bytes.NewReader(data)
+document, err := pdf.Extract(ctx, reader, int64(len(data)))`}</CodeBlock>
+        </DocSubsection>
+
+        <p>
+          If your final output needs Markdown rather than plain text, use{' '}
+          <Link to='/downmark'>Downmark</Link>, which wraps this package with document detection,
+          conversion, CLI support, and other formats.
+        </p>
+      </DocSection>
+
+      <DocSection id='glyphs' title='Glyph positions'>
+        <p>
+          Read <code>Page.Glyphs</code> directly when you need coordinates, font-relative sizing,
+          custom layout analysis, highlighting, or search-result boxes.
+        </p>
+
+        <CodeBlock>{`for pageIndex, page := range document.Pages {
+    for _, glyph := range page.Glyphs {
+        fmt.Printf(
+            "page=%d text=%q x=%.2f y=%.2f advance=%.2f size=%.2f\n",
+            pageIndex+1,
+            glyph.Text,
+            glyph.X,
+            glyph.Y,
+            glyph.Advance,
+            glyph.Size,
+        )
+    }
+}`}</CodeBlock>
+
+        <DocsTable headers={['Field', 'Meaning']}>
+          <tr>
+            <TableCell code>Text</TableCell>
+            <TableCell>Decoded, non-empty text for one glyph or glyph cluster.</TableCell>
+          </tr>
+          <tr>
+            <TableCell code>X, Y</TableCell>
+            <TableCell>Glyph origin in unrotated page space.</TableCell>
+          </tr>
+          <tr>
+            <TableCell code>Advance</TableCell>
+            <TableCell>Horizontal advance used to estimate the end of the glyph.</TableCell>
+          </tr>
+          <tr>
+            <TableCell code>Size</TableCell>
+            <TableCell>Effective font size after the text and transformation matrices.</TableCell>
+          </tr>
+        </DocsTable>
+
+        <Callout>
+          Glyphs preserve positions, not semantic blocks. The package does not label paragraphs,
+          columns, headers, tables, or reading regions; build those decisions from the coordinates
+          when your application needs them.
+        </Callout>
+      </DocSection>
+
+      <DocSection id='behavior' title='Parser behavior'>
+        <p>
+          PDF text is usually a sequence of drawing instructions, not stored paragraphs. The
+          extractor interprets those instructions, tracks the current transformation and text
+          matrices, decodes each font, and then reconstructs lines from final glyph positions.
+        </p>
+
+        <ul>
+          <li>
+            Nested Form XObjects inherit resources and transformations, so text embedded by tools
+            such as Google Docs is included.
+          </li>
+          <li>
+            ToUnicode CMaps, standard font encodings, the Adobe Glyph List, CID widths, and
+            Identity-H composite fonts are used to decode character codes.
+          </li>
+          <li>
+            Content split across multiple <code>/Contents</code> streams is interpreted as one
+            logical stream, even when a token crosses a segment boundary.
+          </li>
+          <li>Inline images are skipped without confusing their binary bytes for operators.</li>
+          <li>
+            Undecodable glyphs are dropped rather than replaced with plausible-looking garbage.
+          </li>
+        </ul>
+
+        <DocSubsection title='Partial results and cancellation'>
+          <p>
+            A malformed file returns an error. Within an otherwise readable file, a malformed page
+            or content stream can retain glyphs decoded before that local failure. The context is
+            checked between pages, so cancellation and deadlines stop multi-page extraction.
+          </p>
+        </DocSubsection>
+      </DocSection>
+
+      <DocSection id='coverage' title='Format coverage'>
+        <DocsTable headers={['Feature', 'Status', 'Notes']}>
+          {coverage.map(([feature, status, notes]) => (
+            <tr key={feature}>
+              <TableCell>{feature}</TableCell>
+              <TableCell code>{status}</TableCell>
+              <TableCell>{notes}</TableCell>
+            </tr>
+          ))}
+        </DocsTable>
+
+        <p>
+          Stream decoding includes the filters needed by text and object data. Image-only filters
+          such as DCT, JPX, CCITT, and JBIG2 are deliberately not decoded because text extraction
+          does not require their pixels.
+        </p>
+      </DocSection>
+
+      <DocSection id='pdftest' title='pdftest helpers'>
+        <p>
+          The <code>github.com/giraffesyo/pdf/pdftest</code> package builds small, deterministic PDF
+          fixtures in memory. It is useful for testing your own PDF pipeline without checking binary
+          fixtures into source control.
+        </p>
+
+        <CodeBlock label='extract_test.go'>{`func TestExtractsGreeting(t *testing.T) {
+    content := pdftest.Stream(
+        "",
+        "BT /F1 12 Tf 72 720 Td (Hello, PDF!) Tj ET",
+    )
+    data := pdftest.Build(
+        1,
+        pdftest.Catalog(2),
+        pdftest.Pages(3),
+        pdftest.Page(2, 4, "<< /Font << /F1 5 0 R >> >>"),
+        content,
+        pdftest.Helvetica(),
+    )
+
+    document, err := pdf.Extract(
+        context.Background(),
+        bytes.NewReader(data),
+        int64(len(data)),
+    )
+    if err != nil {
+        t.Fatal(err)
+    }
+    if got, want := document.Text(), "Hello, PDF!"; got != want {
+        t.Fatalf("Text() = %q, want %q", got, want)
+    }
+}`}</CodeBlock>
+
+        <DocsTable headers={['Helper', 'Use']}>
+          <tr>
+            <TableCell code>Build</TableCell>
+            <TableCell>Assemble numbered objects into a classic PDF with an xref table.</TableCell>
+          </tr>
+          <tr>
+            <TableCell code>Stream / Flate</TableCell>
+            <TableCell>Create plain or Flate-compressed stream objects.</TableCell>
+          </tr>
+          <tr>
+            <TableCell code>BuildXrefStream</TableCell>
+            <TableCell>Build a PDF 1.5 file using a cross-reference stream.</TableCell>
+          </tr>
+          <tr>
+            <TableCell code>BuildObjStm</TableCell>
+            <TableCell>Pack selected indirect objects into an object stream.</TableCell>
+          </tr>
+          <tr>
+            <TableCell code>BuildHybrid</TableCell>
+            <TableCell>Create a hybrid-reference fixture.</TableCell>
+          </tr>
+          <tr>
+            <TableCell code>BuildEncrypted</TableCell>
+            <TableCell>Create a standard-handler encrypted fixture from an EncryptSpec.</TableCell>
+          </tr>
+          <tr>
+            <TableCell code>ToUnicodeCMap / Type0Font</TableCell>
+            <TableCell>Build composite-font fixtures with explicit Unicode mappings.</TableCell>
+          </tr>
+        </DocsTable>
+      </DocSection>
+
+      <DocSection id='safety' title='Safety model'>
+        <p>
+          PDF input is untrusted by default. The parser uses hard budgets and structural validation
+          to prevent malformed files from turning into unbounded CPU, memory, or recursion work.
+        </p>
+
+        <ul>
+          <li>Decoded streams have byte limits, including chained filters.</li>
+          <li>Content interpretation limits operations and emitted glyphs per page.</li>
+          <li>Form XObject recursion is depth-bounded.</li>
+          <li>Page trees are checked for excessive depth, size, and reference cycles.</li>
+          <li>Object, xref, predictor, and CMap parsing use bounded reads and counts.</li>
+        </ul>
+
+        <Callout title='Application limits still matter'>
+          The package bounds parser internals, but your service should still enforce upload size,
+          request deadlines, concurrency, and retained-output limits appropriate to its workload.
+        </Callout>
+      </DocSection>
+
+      <DocSection id='limitations' title='Limitations'>
+        <ul>
+          <li>No OCR for scanned pages or text converted to vector outlines.</li>
+          <li>
+            No semantic layout analysis beyond line and word reconstruction; complex multi-column
+            pages may interleave.
+          </li>
+          <li>
+            Password-protected files fail unless the empty user or owner password unlocks the
+            standard security handler.
+          </li>
+          <li>Image filters are not decoded because the package does not inspect image pixels.</li>
+        </ul>
+
+        <p>
+          The repository includes synthetic coverage tests, real-world regression fixtures, fuzz
+          targets, and a separate benchmark module comparing support and extraction cost with other
+          Go PDF packages.
+        </p>
+
+        <CodeBlock label='Development'>{`go test ./...
+
+cd benchmarks
+go test -run TestCompetitorComparison -v ./...
+go test -bench . -benchmem -run '^$' -count=1 ./...`}</CodeBlock>
+      </DocSection>
+    </DocsPage>
+  )
+}

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -223,6 +223,37 @@ pre {
   visibility: visible;
 }
 
+/* ── Documentation ── */
+
+.docs-content p {
+  @apply text-stone-600 dark:text-zinc-400 leading-relaxed my-4;
+}
+
+.docs-content a {
+  @apply text-accent hover:text-accent-hover underline underline-offset-2 transition-colors;
+}
+
+.docs-content ul,
+.docs-content ol {
+  @apply ml-6 my-5 text-stone-600 dark:text-zinc-400 space-y-2 leading-relaxed;
+}
+
+.docs-content ul {
+  @apply list-disc;
+}
+
+.docs-content ol {
+  @apply list-decimal;
+}
+
+.docs-content li::marker {
+  color: var(--accent);
+}
+
+.docs-content table code {
+  @apply whitespace-nowrap;
+}
+
 /* ── Grain overlay ── */
 
 body::after {


### PR DESCRIPTION
- Add docs for downmark, pdf, and openapi-go-naming
- Add a docs landing page and navigation
- Add scroll tracking and copyable examples